### PR TITLE
Add Extra.find

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -4,6 +4,7 @@ module List.Extra
   , andMap
   , takeWhile
   , dropWhile
+  , find
   , zip
   , zip3
   , zip4
@@ -12,7 +13,7 @@ module List.Extra
 {-| Convenience functions for working with List
 
 # Common Helpers
-@docs maximumBy, minimumBy, andMap, takeWhile, dropWhile
+@docs maximumBy, minimumBy, andMap, takeWhile, dropWhile, find
 
 # Zipping
 @docs zip, zip3, zip4, zip5
@@ -67,6 +68,24 @@ dropWhile predicate list =
 -}
 andMap : List (a -> b) -> List a -> List b
 andMap fl l = map2 (<|) fl l
+
+
+{-| Find the first element that satisfies a predicate and return
+Just that element. If none match, return Nothing.
+    find (\num -> num > 5) [2, 4, 6, 8] == Just 6
+-}
+find : (a -> Bool) -> List a -> Maybe a
+find predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        first::rest ->
+            if predicate first then
+                Just first
+            else
+                find predicate rest
+
 
 {-| Take two lists and returns a list of corresponding pairs
 -}


### PR DESCRIPTION
Per @evancz's [comment on my previous PR into `core`](https://github.com/elm-lang/core/pull/303#issuecomment-123428561), here's a PR to add `find`, a useful function that can be found in several other standard libraries:
- [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)
- [Ruby](http://apidock.com/ruby/Enumerable/find)
- [Scala](http://www.scala-lang.org/api/2.11.5/index.html#scala.collection.immutable.List@find%28p:A=>Boolean%29:Option[A])
- [Haskell](https://hackage.haskell.org/package/base-4.7.0.1/docs/src/Data-List.html#find)
