### PR TITLE
Add ability to drop duplicates by first computing a function on each element.

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -9,6 +9,7 @@ module List.Extra
   , takeWhile
   , dropWhile
   , dropDuplicates
+  , dropDuplicatesBy
   , replaceIf
   , singleton
   , removeWhen
@@ -166,12 +167,21 @@ dropWhile predicate list =
 {-| Drop _all_ duplicate elements from the list
 -}
 dropDuplicates : List comparable -> List comparable
-dropDuplicates list =
-  let
-    step next (set, acc) =
-      if Set.member next set
+dropDuplicates = dropDuplicatesBy identity
+
+
+{-| Drop all duplicate elements from the list, where
+    `f` is computed on each element to determine
+    the comparison value.
+-}
+dropDuplicatesBy : (a -> comparable) -> List a -> List a
+dropDuplicatesBy f list =
+  let step next (set, acc) =
+    let computedNext = f next
+    in
+      if Set.member computedNext set
         then (set, acc)
-        else (Set.insert next set, next::acc)
+        else (Set.insert computedNext set, next :: acc)
   in
     List.foldl step (Set.empty, []) list |> snd |> List.reverse
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -8,8 +8,7 @@ module List.Extra
   , andMap, andThen
   , takeWhile
   , dropWhile
-  , dropDuplicates
-  , dropDuplicatesBy
+  , dropDuplicates, dropDuplicatesBy, dropFirstDuplicatesBy
   , replaceIf
   , singleton
   , removeWhen
@@ -164,18 +163,13 @@ dropWhile predicate list =
     x::xs   -> if (predicate x) then dropWhile predicate xs
                else list
 
-{-| Drop _all_ duplicate elements from the list
+{-| Drops duplicates from a list. It can be configured to either
+    keep only the first of the duplicates, or the last of the
+    duplicates. It can also be configured to run a function to
+    compute the duplicate value for comparison.
 -}
-dropDuplicates : List comparable -> List comparable
-dropDuplicates = dropDuplicatesBy identity
-
-
-{-| Drop all duplicate elements from the list, where
-    `f` is computed on each element to determine
-    the comparison value.
--}
-dropDuplicatesBy : (a -> comparable) -> List a -> List a
-dropDuplicatesBy f list =
+baseDropDuplicates : (List a -> List a) -> (List a -> List a) -> (a -> comparable) -> List a -> List a
+baseDropDuplicates pre post f list =
   let step next (set, acc) =
     let computedNext = f next
     in
@@ -183,7 +177,31 @@ dropDuplicatesBy f list =
         then (set, acc)
         else (Set.insert computedNext set, next :: acc)
   in
-    List.foldl step (Set.empty, []) list |> snd |> List.reverse
+    List.foldl step (Set.empty, []) (pre list) |> snd |> post
+
+
+{-| Drops all the duplicate elements in the list, but preserves the
+    first.
+-}
+dropDuplicates : List comparable -> List comparable
+dropDuplicates = dropDuplicatesBy identity
+
+
+{-| Drop all duplicate elements from the list, where
+    `f` is computed on each element to determine
+    the comparison value. Only the first is preserved.
+-}
+dropDuplicatesBy : (a -> comparable) -> List a -> List a
+dropDuplicatesBy = baseDropDuplicates identity List.reverse
+
+
+{-| Drop all duplicate elements from the list, where
+    `f` is computed on each element to determine
+    the comparison value. Only the last is preserved.
+-}
+dropFirstDuplicatesBy : (a -> comparable) -> List a -> List a
+dropFirstDuplicatesBy = baseDropDuplicates List.reverse identity
+
 
 {-| Map functions taking multiple arguments over multiple lists. Each list should be of the same length.
 


### PR DESCRIPTION
This pull request adds
1. `dropDuplicatesBy`, which allows a user-specified function to be computed to determine the duplicate value
2. `dropFirstDuplicatesBy`, which preserves only the last in the series of duplicates
