### PR TITLE
Add `unique`

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -384,21 +384,20 @@ interweaveHelp l1 l2 acc =
 -}
 unique : List comparable -> List comparable
 unique list =
-  uniqueHelp Set.empty [] list
-    |> List.reverse
+  uniqueHelp Set.empty list
 
 
-uniqueHelp : Set comparable -> List comparable -> List comparable -> List comparable
-uniqueHelp existing result remaining =
+uniqueHelp : Set comparable -> List comparable -> List comparable
+uniqueHelp existing remaining =
   case remaining of
     [] ->
-      result
+      []
 
     first :: rest ->
       if Set.member first existing then
-        uniqueHelp existing result rest
+        uniqueHelp existing rest
       else
-        uniqueHelp (Set.insert first existing) (first :: result) rest
+        first :: uniqueHelp (Set.insert first existing) rest
 
 
 {-| Variant of `foldl` that has no starting value argument and treats the head of the list as its starting value. If the list is empty, return `Nothing`.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -13,7 +13,7 @@ module List.Extra
   , singleton
   , removeWhen
   , iterate
-  , intercalate, transpose, subsequences, permutations, interweave
+  , intercalate, transpose, subsequences, permutations, interweave, unique
   , foldl1, foldr1
   , scanl1, scanr, scanr1, unfoldr
   , splitAt, takeWhileEnd, dropWhileEnd, span, break, stripPrefix
@@ -35,7 +35,7 @@ module List.Extra
 @docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, dropDuplicates, find, replaceIf, singleton, removeWhen
 
 # List transformations
-@docs intercalate, transpose, subsequences, permutations, interweave
+@docs intercalate, transpose, subsequences, permutations, interweave, unique
 
 # Folds
 @docs foldl1, foldr1
@@ -60,7 +60,7 @@ module List.Extra
 -}
 
 import List exposing (..)
-import Set
+import Set exposing (Set)
 
 
 {-| Extract the last element of a list.
@@ -378,6 +378,27 @@ interweaveHelp l1 l2 acc =
 
     ([], y) ->
       acc ++ y
+
+
+{-| Remove all duplicates from a list and return a list of distinct elements.
+-}
+unique : List comparable -> List comparable
+unique list =
+  uniqueHelp Set.empty [] list
+    |> List.reverse
+
+
+uniqueHelp : Set comparable -> List comparable -> List comparable -> List comparable
+uniqueHelp existing result remaining =
+  case remaining of
+    [] ->
+      result
+
+    first :: rest ->
+      if Set.member first existing then
+        uniqueHelp existing result rest
+      else
+        uniqueHelp (Set.insert first existing) (first :: result) rest
 
 
 {-| Variant of `foldl` that has no starting value argument and treats the head of the list as its starting value. If the list is empty, return `Nothing`.


### PR DESCRIPTION
We wanted a `unique` function and realized the only place we could get it was in [elm-lazy-list's `unique` function](http://package.elm-lang.org/packages/NoRedInk/elm-lazy-list/2.0.0/Lazy-List#unique).

Seemed pretty silly to convert to a Lazy List and then back again just to get this, so here's a PR to add it!
